### PR TITLE
Add feature to disable highlighting of minified files

### DIFF
--- a/config/filament-simple-highlight-field.php
+++ b/config/filament-simple-highlight-field.php
@@ -15,4 +15,19 @@ return [
 
     // 'theme' => 'nord',
 
+    /*
+    |-----------------------------------------------------------------------------
+    | Should minified files be highlighted?
+    |-----------------------------------------------------------------------------
+    |
+    | To save on the client's resources, files with a very long line length, ie
+    | files that are likely to be minified, are not highlighted by default.
+    | You can change this behaviour here, and you can also change the
+    | threshold for what is considered to be a "very long" line.
+    |
+    */
+
+    'disable_highlighting_for_compact_files' => true,
+    'compact_file_line_threshold' => 256,
+
 ];

--- a/resources/views/highlight-field.blade.php
+++ b/resources/views/highlight-field.blade.php
@@ -19,16 +19,18 @@
     >{{ $getState() }}</code></pre>
 </x-dynamic-component>
 
-@once
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/{{ config('filament-simple-highlight-field.theme', 'default') }}.min.css">
+@if(\Desilva\FilamentSimpleHighlightField\HighlightField::canHighlight($getState()))
+    @once
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/{{ config('filament-simple-highlight-field.theme', 'default') }}.min.css">
 
-    @push('scripts')
-        <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.6.0/build/highlight.min.js"></script>
+        @push('scripts')
+            <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.6.0/build/highlight.min.js"></script>
 
-        <script type="text/javascript">
-            window.addEventListener('DOMContentLoaded', function() {
-                hljs.highlightAll();
-            });
-        </script>
-    @endpush
-@endonce
+            <script type="text/javascript">
+                window.addEventListener('DOMContentLoaded', function() {
+                    hljs.highlightAll();
+                });
+            </script>
+        @endpush
+    @endonce
+@endif

--- a/resources/views/highlight-field.blade.php
+++ b/resources/views/highlight-field.blade.php
@@ -15,7 +15,7 @@
         {{ $attributes ->class([
             'bg-white px-3 py-2 rounded-md block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70 filament-forms-textarea-component',
             'dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:focus:border-primary-600' => config('forms.dark_mode'),
-        ])->merge(['style' => 'background: '.(config('forms.dark_mode') ? '#292d3e' : 'white').'; border: 1px solid #'.(config('forms.dark_mode') ? '38414f' : 'dbdee3').'; font-family: monospace; font-size: 1.1em;']) }}
+        ])->merge(['style' => 'background: '.(config('forms.dark_mode') ? '#292d3e' : 'white').'; border: 1px solid #'.(config('forms.dark_mode') ? '38414f' : 'dbdee3').'; font-family: monospace; font-size: 1.1em; overflow: auto;']) }}
     >{{ $getState() }}</code></pre>
 </x-dynamic-component>
 

--- a/src/HighlightField.php
+++ b/src/HighlightField.php
@@ -7,4 +7,20 @@ use Filament\Forms\Components\Field;
 class HighlightField extends Field
 {
     protected string $view = 'filament-simple-highlight-field::highlight-field';
+
+    public static function canHighlight(string $string): bool
+    {
+        if (config('filament-simple-highlight-field.disable_highlighting_for_compact_files', true)) {
+            $lines = substr_count($string, "\n");
+            $chars = strlen($string);
+
+            $threshold = config('filament-simple-highlight-field.compact_file_line_threshold', 256);
+
+            if (($lines > 0) && ($chars / $lines > $threshold)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/HighlightField.php
+++ b/src/HighlightField.php
@@ -11,16 +11,21 @@ class HighlightField extends Field
     public static function canHighlight(string $string): bool
     {
         if (config('filament-simple-highlight-field.disable_highlighting_for_compact_files', true)) {
-            $lines = substr_count($string, "\n");
-            $chars = strlen($string);
-
-            $threshold = config('filament-simple-highlight-field.compact_file_line_threshold', 256);
-
-            if (($lines > 0) && ($chars / $lines > $threshold)) {
+            if (static::areLinesTooLongToBeHighlighted($string)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    protected static function areLinesTooLongToBeHighlighted(string $string): bool
+    {
+        $lines = substr_count($string, "\n");
+        $chars = strlen($string);
+
+        $threshold = config('filament-simple-highlight-field.compact_file_line_threshold', 256);
+
+        return ($lines > 0) && ($chars / $lines > $threshold);
     }
 }


### PR DESCRIPTION
To save on the client's resources, files with a very long line length, ie files that are likely to be minified, are not highlighted by default. You can change this behaviour in the config, and you can also change the threshold for what is considered to be a "very long" line.